### PR TITLE
Proposed improvement to M-INIT-CASCADED example

### DIFF
--- a/src/guidelines/libs/ux/M-INIT-CASCADED.md
+++ b/src/guidelines/libs/ux/M-INIT-CASCADED.md
@@ -8,10 +8,10 @@
 Types that require 4+ parameters should cascade their initialization via helper types.
 
 ```rust, ignore
-# struct Transaction;
-impl Transaction {
+# struct Deposit;
+impl Deposit {
     // Easy to confuse parameters and signature generally unwieldy.
-    pub fn new(from_bank: &str, from_customer: &str, to_bank: &str, to_customer: &str) -> Self { }
+    pub fn new(bank_name: &str, customer_name: &str, currency_name: &str, currency_amount: u64) -> Self { }
 }
 ```
 
@@ -19,11 +19,12 @@ Instead of providing a long parameter list, parameters should be grouped semanti
 also check if [C-NEWTYPE] is applicable:
 
 ```rust, ignore
-# struct Transaction;
+# struct Deposit;
 # struct Account;
-impl Transaction {
+# struct Currency
+impl Deposit {
     // Better, signature cleaner
-    pub fn new(from: Account, to: Account) -> Self { }
+    pub fn new(account: Account, amount: Currency) -> Self { }
 }
 
 impl Account {


### PR DESCRIPTION
I agree with the recommendations in [`M-INIT-CASCADED`](https://microsoft.github.io/rust-guidelines/guidelines/libs/ux/index.html#M-INIT-CASCADED) but I think the stated aim of "To prevent misuse and accidental parameter mix ups" and the example provided represents a potentially problematic anti-pattern involving parameter mix ups.

This is the current example:

```rust
impl Transaction {
    // Better, signature cleaner
    pub fn new(from: Account, to: Account) -> Self { }
}

impl Account {
    pub fn new_ok(bank: &str, customer: &str) -> Self { }
    pub fn new_even_better(bank: Bank, customer: Customer) -> Self { }
}
```

Here `Transaction::new` has a potentially risky parameter list because it's very easy to get the `from` and `to` parameters mixed up. 

I think an alternative suggestion is that if you have order-dependant, but otherwise identical, types in a function then you should consider the builder pattern. Something like:

```rust
impl TransactionBuilder {
    pub fn from_account(self, from: Account) -> Self {
        // ...
    }
    pub fn to_account(self, to: Account) -> Self {
        // ...
    }
    // ...
}
```

We of course don't want to overload `M-INIT-CASCADED` with this extra recommendation, which could be added separately, but we might prefer if the example didn't expose this potential anti-pattern? This PR provides an alternative pattern.

The example I've gone for uses a `Deposit` of `Currency` within an `Account`. It uses 3 `&str` and a numeric to represent the deposit. I'm of course open to other examples if anyone can think of them but this one kept in the theme of the previous example.