### PR TITLE
Propose stable clippy lint group instead of unstable.

### DIFF
--- a/src/guidelines/universal/M-STATIC-VERIFICATION.md
+++ b/src/guidelines/universal/M-STATIC-VERIFICATION.md
@@ -42,10 +42,11 @@ Undesired lints (e.g., numeric casts) can be opted back out of on a case-by-case
 cargo = { level = "warn", priority = -1 }
 complexity = { level = "warn", priority = -1 }
 correctness = { level = "warn", priority = -1 }
-suspicious = { level = "warn", priority = -1 }
 pedantic = { level = "warn", priority = -1 }
 perf = { level = "warn", priority = -1 }
 style = { level = "warn", priority = -1 }
+suspicious = { level = "warn", priority = -1 }
+# nursery = { level = "warn", priority = -1 }  # optional, might cause more false positives
 
 # These lints are from the `restriction` lint group and prevent specific
 # constructs being used in source code in order to drive up consistency,


### PR DESCRIPTION
From the clippy lint docs (https://doc.rust-lang.org/clippy/lints.html#nursery):
> The clippy::nursery group contains lints which are buggy or need more work. It is **not** recommended to enable the whole group, but rather cherry-pick lints that are useful for your code base and your use case.

I propose to include suspicious lint group instead (https://doc.rust-lang.org/clippy/lints.html#suspicious):
> The clippy::suspicious group is similar to the correctness lints in that it contains lints that trigger on code that is really *sus* and should be fixed. As opposed to correctness lints, it might be possible that the linted code is intentionally written like it is.