### PR TITLE
Fix parameter names in copy function example

### DIFF
--- a/src/guidelines/docs/M-CANONICAL-DOCS.md
+++ b/src/guidelines/docs/M-CANONICAL-DOCS.md
@@ -46,7 +46,7 @@ but instead:
 
 ```rust,ignore
 /// Copies a file from `src` to `dst`.
-fn copy(from: File, to: File) {}
+fn copy(src: File, dst: File) {}
 ```
 
 ### Related Reading


### PR DESCRIPTION
I think the function signatures were unintentionally different between the "bad style" and "good style" examples for documenting function parameters. This brings the functions back into sync.